### PR TITLE
Ca feature/cancel message

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Define relations of subjects and channels
 
 ```json
 {
-  "messages": [{
+  "criterias": [{
     "id": "t1",
     "name": "low",
     "value": 86400
@@ -344,18 +344,15 @@ Define relations of subjects and channels
 - [X] Define and implements mocks struct models (ca)
 - [X] Implement mock to `GET /api/v1/subject` endpoint (ca)
 - [X] Implement `GET /api/v1/messages/:id/status` endpoint (ca)
-- [ ] Implement status method on pigeon-go client (mt) 
-- [ ] Implement `POST /api/v1/messages/:id/cancel` endpoint (ca)
-- [ ] Handle cancellation in scheduler.go file (ja)
-- [ ] Implement rpc route for cancel message by id (ca)
+- [X] Implement status method on pigeon-go client (mt)
+- [X] Implement `POST /api/v1/messages/:id/cancel` endpoint (ca)
+- [X] Handle cancellation in scheduler.go file (ca)
+- [X] Implement rpc route for cancel message by id (ca)
 - [ ] Implement cancel method on `pigeon-go` client (mt)
 - [X] Define and implement `pigeon-http` channel (ca)
 - [X] Add `pigeon-http` value to subject model {options: {headers}} (ca)
 - [ ] Implement 'callback_post_url' using pigeon-http service inside scheduler.go file (ca)
 - [X] Append user-channels `options` to content message by channel (ca)
-- [ ] Implement `Subjects` table on `BoltDB` (ca)
-- [ ] Implement `Subject Channels` table on `BoltDB` (ca)
-- [ ] Implement `Users` table on `BoltDB` (ca)
 - [X] Add 'data.json' on docker (ca)
 - [X] Implement `Messages` table on `BoltDB` (ca)
 - [X] Add Status on `Messages` protobuf (ca)
@@ -367,9 +364,14 @@ Define relations of subjects and channels
 - [X] Add criteria examples to mock (ca)
 - [X] Implement criteria when create new message (ca)
 - [ ] Should use cron tab in criteria_value (ca)
-- [ ] Implement interface for any model
-- [ ] Return Subject when has create
-- [ ] Implement JWT in any request
+- [ ] Implement interface for any model (mt)
+- [ ] Return Subject when has create (ca)
+- [ ] Implement JWT in any request (ca)
+- [ ] Implement arangodb on any model (key-value for now) (mt)
+- [ ] Implement test for check endpoint (mt)
+- [ ] Remove 'Endpoint' value from Message model (ca)
+- [X] Implement POST /messages/:id. (http, rcp, scheduler, message model, priority queue) (ca)
+- [X] Fix error on Pop method (scrips.go:22, scheduler.go:192) when pop element and there is none in the queue (ca)
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Define relations of subjects and channels
 - [ ] Implement arangodb on any model (key-value for now) (mt)
 - [ ] Implement test for check endpoint (mt)
 - [ ] Remove 'Endpoint' value from Message model (ca)
-- [X] Implement POST /messages/:id. (http, rcp, scheduler, message model, priority queue) (ca)
+- [X] Implement GET /messages/:id. (http, rcp, scheduler, message model, priority queue) (ca)
 - [X] Fix error on Pop method (scrips.go:22, scheduler.go:192) when pop element and there is none in the queue (ca)
 
 ```json

--- a/db/messages.go
+++ b/db/messages.go
@@ -1,8 +1,6 @@
 package db
 
 import (
-	"fmt"
-
 	"github.com/boltdb/bolt"
 	"github.com/gogo/protobuf/proto"
 	"github.com/iampigeon/pigeon"
@@ -16,22 +14,6 @@ type MessageStore struct {
 	*Datastore
 }
 
-// GetMessages ...
-// func (ss *MessageStore) GetMessages() ([]*pigeon.Message, error) {
-// 	data, err := ioutil.ReadFile("../data.json")
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	var mock pigeon.Mock
-// 	err = json.Unmarshal(data, &mock)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	return mock.Messages, nil
-// }
-
 // AddMessage ...
 func (ss *MessageStore) AddMessage(m pigeon.Message) error {
 	err := ss.DB.Update(func(tx *bolt.Tx) error {
@@ -41,11 +23,13 @@ func (ss *MessageStore) AddMessage(m pigeon.Message) error {
 		if merr != nil {
 			return merr
 		}
+
 		v, jerr := proto.Marshal(&pb.Message{
-			Id:       m.ID.String(),
-			Content:  m.Content,
-			Endpoint: string(m.Endpoint),
-			Status:   string(m.Status),
+			Id:        m.ID.String(),
+			Content:   m.Content,
+			Endpoint:  string(m.Endpoint),
+			Status:    string(m.Status),
+			SubjectId: string(m.SubjectID),
 		})
 		if jerr != nil {
 			return jerr
@@ -55,8 +39,6 @@ func (ss *MessageStore) AddMessage(m pigeon.Message) error {
 	if err != nil {
 		return err
 	}
-
-	fmt.Println("se guardo")
 
 	return nil
 }
@@ -82,10 +64,11 @@ func (ss *MessageStore) GetMessage(id ulid.ULID) (*pigeon.Message, error) {
 	}
 
 	return &pigeon.Message{
-		ID:       id,
-		Content:  msg.Content,
-		Endpoint: pigeon.NetAddr(msg.Endpoint),
-		Status:   pigeon.MessageStatus(msg.Status),
+		ID:        id,
+		Content:   msg.Content,
+		Endpoint:  pigeon.NetAddr(msg.Endpoint),
+		Status:    pigeon.MessageStatus(msg.Status),
+		SubjectID: msg.SubjectId,
 	}, nil
 }
 

--- a/db/subjects.go
+++ b/db/subjects.go
@@ -60,3 +60,19 @@ func (ss *SubjectStore) GetUserSubjectByName(userID string, name string) (*pigeo
 
 	return nil, errors.New("subject not found")
 }
+
+// GeSubjectByID ...
+func (ss *SubjectStore) GeSubjectByID(ID string) (*pigeon.Subject, error) {
+	mock, err := getMock()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, subject := range mock.Subjects {
+		if subject.ID == ID {
+			return subject, nil
+		}
+	}
+
+	return nil, errors.New("subject not found")
+}

--- a/httpsvc/httpsvc.go
+++ b/httpsvc/httpsvc.go
@@ -138,6 +138,7 @@ type getMessageByIDContext struct {
 //
 // GET /api/v1/subjects
 // POST /api/v1/messages
+// GET /api/v1/messages/:id
 // GET /api/v1/messages/:id/status
 // POST /api/v1/messages/:id/cancel
 //

--- a/pigeon.go
+++ b/pigeon.go
@@ -20,6 +20,8 @@ const (
 	StatusFailedDeliver = "failed-deliver"
 	// StatusCrashedDeliver ...
 	StatusCrashedDeliver = "crashed-deliver"
+	// StatusCancelled ...
+	StatusCancelled = "cancelled"
 )
 
 // NetAddr is the network address of the Backend service where to validate and
@@ -68,6 +70,9 @@ type SchedulerService interface {
 
 	// Update updates the content of the message with the given id.
 	Update(id ulid.ULID, content []byte) error
+
+	// Cancel cancel the message with the given id.
+	Cancel(id ulid.ULID) error
 }
 
 // Backend manages the approval and delivery of messages.

--- a/proto/pigeon.proto
+++ b/proto/pigeon.proto
@@ -41,6 +41,7 @@ service SchedulerService {
     rpc Put(PutRequest) returns (PutResponse) {}
     rpc Get(GetRequest) returns (GetResponse) {}
     rpc Update(UpdateRequest) returns (UpdateResponse) {}
+    rpc Cancel(CancelRequest) returns (CancelResponse) {}
 }
 
 message PutRequest {
@@ -51,6 +52,14 @@ message PutRequest {
 }
 
 message PutResponse {
+    Error error = 1;
+}
+
+message CancelRequest {
+    string id       = 1;
+}
+
+message CancelResponse {
     Error error = 1;
 }
 

--- a/rpc/scheduler/scheduler.go
+++ b/rpc/scheduler/scheduler.go
@@ -49,10 +49,11 @@ func (s *Service) Get(ctx context.Context, r *pb.GetRequest) (*pb.GetResponse, e
 
 	return &pb.GetResponse{
 		Message: &pb.Message{
-			Id:       r.Id,
-			Content:  msg.Content,
-			Endpoint: string(msg.Endpoint),
-			Status:   string(msg.Status),
+			Id:        r.Id,
+			Content:   msg.Content,
+			Endpoint:  string(msg.Endpoint),
+			Status:    string(msg.Status),
+			SubjectId: string(msg.SubjectID),
 		},
 	}, nil
 }
@@ -67,4 +68,17 @@ func (s *Service) Update(ctx context.Context, r *pb.UpdateRequest) (*pb.UpdateRe
 	}
 
 	return &pb.UpdateResponse{}, nil
+}
+
+// Cancel ...
+func (s *Service) Cancel(ctx context.Context, r *pb.CancelRequest) (*pb.CancelResponse, error) {
+	id, err := ulid.Parse(r.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.schedulerSvc.Cancel(id); err != nil {
+		return nil, err
+	}
+	return &pb.CancelResponse{}, nil
 }


### PR DESCRIPTION
- [X] Implement `POST /api/v1/messages/:id/cancel` endpoint (ca)
- [X] Handle cancellation in scheduler.go file (ca)
- [X] Implement rpc route for cancel message by id (ca)
- [X] Implement GET /messages/:id. (http, rcp, scheduler, message model, priority queue) (ca)
- [X] Fix error on Pop method (scrips.go:22, scheduler.go:192) when pop element and there is none in the queue (ca)